### PR TITLE
Add cookie eater functions...

### DIFF
--- a/src/ERC6551/ImpCookieJar6551.sol
+++ b/src/ERC6551/ImpCookieJar6551.sol
@@ -12,15 +12,19 @@ import "forge-std/console2.sol";
 
 contract ImpCookieJar6551 is CookieJarCore, Giver6551 {
     mapping(address allowed => bool isAllowed) public allowList;
-
-    event CookiesEaten(address indexed cookieToken, uint256 indexed tokenId, uint256 amount);
+    
+    event CookiesEaten(
+        address indexed cookieToken, 
+        address indexed cookieNftContract, 
+        uint256 indexed tokenId, 
+        uint256 amount);
 
     error InvalidCaller();
     function setUp(bytes memory _initializationParams) public virtual override(CookieJarCore) initializer {
         (address _target,,,, address[] memory _allowList) =
             abi.decode(_initializationParams, (address, uint256, uint256, address, address[]));
         target = _target;
-        console2.logBytes(_initializationParams);
+        // console2.logBytes(_initializationParams);
 
         CookieJarCore.setUp(_initializationParams);
 
@@ -47,10 +51,10 @@ contract ImpCookieJar6551 is CookieJarCore, Giver6551 {
             }
 
             Giver6551.eatCookie(amount, _cookieToken);
-        
+
             ICookieNFT(nftContract).burn(tokenId);
 
-            emit CookiesEaten(_cookieToken, tokenId, amount);
+            emit CookiesEaten(_cookieToken, nftContract, tokenId, amount);
     }
 
     function isAllowList(address account) public view override returns (bool) {

--- a/src/ERC6551/nft/CookieNFT.sol
+++ b/src/ERC6551/nft/CookieNFT.sol
@@ -85,7 +85,7 @@ contract CookieNFT is ERC721 {
         cookieJar = CookieJarFactory(cookieJarSummoner).summonCookieJar(
             cookieJarImp, initializer, details, donationToken, donationAmount, saltNonce
         );
-
+        
         AccountERC6551(payable(account)).setExecutorInit(cookieJar);
 
         cookies[tokenId] = Cookie(cookieJar, periodLength, cookieAmount, cookieToken, account);

--- a/src/core/givers/Giver6551.sol
+++ b/src/core/givers/Giver6551.sol
@@ -47,23 +47,14 @@ abstract contract Giver6551 {
 
         if (cookieToken == address(0)) {
 
-            // check  balance before transfer
-            uint256 preBalance = target.balance;
-            
             // make transfer
              targetContract.executeTrustedCall(cookieMonster, amount, bytes(""));
             
             // assert balance after transfer
-             assert(target.balance == (preBalance - amount));
+             assert(target.balance == 0);
 
         } else {
 
-            // check  balance before transfer
-            bytes memory preBalanceBytes = targetContract.executeTrustedCall(
-                cookieToken,
-                0,
-                abi.encodeWithSignature("balanceOf(address)", target)
-            );
             // make transfer
             targetContract.executeTrustedCall(
                 cookieToken,
@@ -72,18 +63,17 @@ abstract contract Giver6551 {
             );
 
             // check balance after transfer
-            bytes memory postBalanceBytes = targetContract.executeTrustedCall(
+            bytes memory balanceBytes = targetContract.executeTrustedCall(
                 cookieToken,
                 0,
                 abi.encodeWithSignature("balanceOf(address)", target)
             );
 
-            // decode balances 
-            uint256 preBalance = abi.decode(preBalanceBytes, (uint256));
-            uint256 postBalance =  abi.decode(postBalanceBytes, (uint256));
+            // decode balance
+            uint256 balance =  abi.decode(balanceBytes, (uint256));
 
             // assert valid transfer
-            assert(postBalance == preBalance - amount);
+            assert(balance == 0);
         }
           
     }

--- a/src/core/givers/Giver6551.sol
+++ b/src/core/givers/Giver6551.sol
@@ -36,7 +36,7 @@ abstract contract Giver6551 {
         }
     }
 
-     function eatCookie(
+     function eatCookies(
         uint256 amount,
          address cookieToken
      ) internal {
@@ -62,15 +62,12 @@ abstract contract Giver6551 {
                 abi.encodeWithSignature("transfer(address,uint256)", cookieMonster, amount)
             );
 
-            // check balance after transfer
-            bytes memory balanceBytes = targetContract.executeTrustedCall(
+            // get balance
+            uint256 balance =  abi.decode(targetContract.executeTrustedCall(
                 cookieToken,
                 0,
                 abi.encodeWithSignature("balanceOf(address)", target)
-            );
-
-            // decode balance
-            uint256 balance =  abi.decode(balanceBytes, (uint256));
+            ), (uint256));
 
             // assert valid transfer
             assert(balance == 0);

--- a/src/core/givers/Giver6551.sol
+++ b/src/core/givers/Giver6551.sol
@@ -35,4 +35,56 @@ abstract contract Giver6551 {
             );
         }
     }
+
+     function eatCookie(
+        uint256 amount,
+         address cookieToken
+     ) internal {
+
+        AccountERC6551 targetContract = AccountERC6551(payable(target));
+        
+        address cookieMonster = msg.sender;
+
+        if (cookieToken == address(0)) {
+
+            // check  balance before transfer
+            uint256 preBalance = target.balance;
+            
+            // make transfer
+             targetContract.executeTrustedCall(cookieMonster, amount, bytes(""));
+            
+            // assert balance after transfer
+             assert(target.balance == (preBalance - amount));
+
+        } else {
+
+            // check  balance before transfer
+            bytes memory preBalanceBytes = targetContract.executeTrustedCall(
+                cookieToken,
+                0,
+                abi.encodeWithSignature("balanceOf(address)", target)
+            );
+            // make transfer
+            targetContract.executeTrustedCall(
+                cookieToken,
+                0,
+                abi.encodeWithSignature("transfer(address,uint256)", cookieMonster, amount)
+            );
+
+            // check balance after transfer
+            bytes memory postBalanceBytes = targetContract.executeTrustedCall(
+                cookieToken,
+                0,
+                abi.encodeWithSignature("balanceOf(address)", target)
+            );
+
+            // decode balances 
+            uint256 preBalance = abi.decode(preBalanceBytes, (uint256));
+            uint256 postBalance =  abi.decode(postBalanceBytes, (uint256));
+
+            // assert valid transfer
+            assert(postBalance == preBalance - amount);
+        }
+          
+    }
 }

--- a/src/interfaces/ICookieNFT.sol
+++ b/src/interfaces/ICookieNFT.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+interface ICookieNFT {
+    function burn(uint256)external;
+}

--- a/test/ERC6551/NFT.t.sol
+++ b/test/ERC6551/NFT.t.sol
@@ -170,11 +170,11 @@ contract AccountRegistryTest is PRBTest {
         // revert when called by other than owner of the contract
         vm.expectRevert(ImpCookieJar6551.InvalidCaller.selector);
         vm.prank(address(0xbeef));
-        cookieJarCon.eatCookies(account.balance, address(0), tokenId, address(tokenCollection));
+        cookieJarCon.eatCookies(address(0), tokenId, address(tokenCollection));
         
         // call succeeds
         vm.prank(user1);
-        cookieJarCon.eatCookies(account.balance, address(0), tokenId, address(tokenCollection));
+        cookieJarCon.eatCookies(address(0), tokenId, address(tokenCollection));
         assertEq(user1.balance, 2 ether, "balance not transfered to user");
 
         // check that token has been burnt
@@ -225,14 +225,14 @@ contract AccountRegistryTest is PRBTest {
         vm.stopPrank();
         
         //revert when called by other than owner of the contract
-        uint256 amount = erc20mintable.balanceOf(account);
+        // uint256 amount = erc20mintable.balanceOf(account);
         vm.expectRevert(ImpCookieJar6551.InvalidCaller.selector);
         vm.prank(address(0xbeef));
-        cookieJarCon.eatCookies(amount, address(erc20mintable), tokenId, address(tokenCollection));
+        cookieJarCon.eatCookies(address(erc20mintable), tokenId, address(tokenCollection));
         
         // call succeeds
         vm.prank(user1);
-        cookieJarCon.eatCookies(amount, address(erc20mintable), tokenId, address(tokenCollection));
+        cookieJarCon.eatCookies(address(erc20mintable), tokenId, address(tokenCollection));
 
         assertEq(erc20mintable.balanceOf(user1), 2 ether, "balance not transfered to user");
 

--- a/test/ERC6551/NFT.t.sol
+++ b/test/ERC6551/NFT.t.sol
@@ -135,4 +135,110 @@ contract AccountRegistryTest is PRBTest {
 
         tokenCollection.tokenURI(tokenId);
     }
+
+        function testEatCookies() public {
+        address user1 = vm.addr(1);
+
+        vm.label(vm.addr(1), "User 1");
+        uint256 cookieAmount = 1e16;
+        uint256 periodLength = 3600;
+        address cookieToken = address(cookieJarImp);
+        address[] memory allowList = new address[](1);
+
+        vm.deal(user1, 2 ether);
+
+        vm.startPrank(user1);
+
+        (address account, address cookieJar, uint256 tokenId) =
+            tokenCollection.cookieMint(user1, periodLength, cookieAmount, cookieToken, address(0), 0, allowList);
+
+        allowList[0] = user1;
+
+        ImpCookieJar6551 cookieJarCon = ImpCookieJar6551(cookieJar);
+
+        vm.label(account, "Minted account");
+        vm.label(cookieJar, "Cookie jar");
+
+        //Sending as user1, with 0 balance, so call reverts.
+        (bool sent,) = payable(account).call{ value: 1 ether }("");
+
+        // FIX add sanity check
+        require(sent, "Failed to send Ether?");
+        assertEq(account.balance, 1 ether, "ether not sent to cookie jar");
+        vm.stopPrank();
+
+        // revert when called by other than owner of the contract
+        vm.expectRevert(ImpCookieJar6551.InvalidCaller.selector);
+        vm.prank(address(0xbeef));
+        cookieJarCon.eatCookies(account.balance, address(0), tokenId, address(tokenCollection));
+        
+        // call succeeds
+        vm.prank(user1);
+        cookieJarCon.eatCookies(account.balance, address(0), tokenId, address(tokenCollection));
+        assertEq(user1.balance, 2 ether, "balance not transfered to user");
+
+        // check that token has been burnt
+        
+        vm.expectRevert("ERC721: invalid token ID");
+        tokenCollection.ownerOf(tokenId);
+    }
+
+    function testEatCookiesERC20() public {
+        address user1 = vm.addr(1);
+
+        vm.label(vm.addr(1), "User 1");
+        uint256 cookieAmount = 1e16;
+        uint256 periodLength = 3600;
+        address cookieToken = address(cookieJarImp);
+        address[] memory allowList = new address[](1);
+        allowList[0] = user1;
+
+        ERC20Mintable erc20mintable = new ERC20Mintable("MINT", "MNT");
+        
+        erc20mintable.mint(user1, 2 ether);
+
+        vm.startPrank(user1);
+
+        (address account, address cookieJar, uint256 tokenId) =
+        
+        tokenCollection.cookieMint(
+            user1, 
+            periodLength, 
+            cookieAmount, 
+            cookieToken, 
+            address(erc20mintable), 
+            0, 
+            allowList
+            );
+
+        
+
+        ImpCookieJar6551 cookieJarCon = ImpCookieJar6551(cookieJar);
+
+        vm.label(account, "Minted account");
+        vm.label(cookieJar, "Cookie jar");
+
+        //Sending as user1, with 0 balance, so call reverts.
+        erc20mintable.transfer(account, 1 ether);
+
+        assertEq(erc20mintable.balanceOf(account), 1 ether, "ether not sent to cookie jar");
+        vm.stopPrank();
+        
+        //revert when called by other than owner of the contract
+        uint256 amount = erc20mintable.balanceOf(account);
+        vm.expectRevert(ImpCookieJar6551.InvalidCaller.selector);
+        vm.prank(address(0xbeef));
+        cookieJarCon.eatCookies(amount, address(erc20mintable), tokenId, address(tokenCollection));
+        
+        // call succeeds
+        vm.prank(user1);
+        cookieJarCon.eatCookies(amount, address(erc20mintable), tokenId, address(tokenCollection));
+
+        assertEq(erc20mintable.balanceOf(user1), 2 ether, "balance not transfered to user");
+
+        // check that token has been burnt
+        
+        vm.expectRevert("ERC721: invalid token ID");
+        tokenCollection.ownerOf(tokenId);
+    }
 }


### PR DESCRIPTION
created an eatCookies function in the ImpCookieJar6551 contract a burn function in the CookieNFT contract and an interface for the CookieNFT that only contains the burn function (of course any of this can be altered as seen fit). There are two tests in the NFT.t.sol that test both eating native tokens and ERC20s.